### PR TITLE
highlight html embedded reference

### DIFF
--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -149,7 +149,7 @@ export const Search = () => {
               {summary?.status === "success" ? (
                 <>
                   <div
-                    className="[&>ol]:pl-6 [&>ol]:list-decimal [&>ul]:pl-6 [&>ul]:list-disc"
+                    className="[&>ol]:pl-6 [&>ol]:list-decimal [&>ul]:pl-6 [&>ul]:list-disc [&>p>a]:text-blue-500 [&>p>a]:font-semibold"
                     dangerouslySetInnerHTML={{ __html: summary.summary }}
                   />
 


### PR DESCRIPTION
In `v2/summary` references are formatted as HTML a tags by default. Adding tailwind classes to target these links.